### PR TITLE
Update MotionBlurCamera.cpp

### DIFF
--- a/src/motionblur/MotionBlurCamera.cpp
+++ b/src/motionblur/MotionBlurCamera.cpp
@@ -53,7 +53,7 @@ void MotionBlurCamera::setViewport(const Vector2i& size) {
     /* Initialize previous frames with black color */
     std::size_t textureSize = size.product()*framebuffer.pixelSize();
     UnsignedByte* texture = new UnsignedByte[textureSize]();
-    framebuffer.setData(size, ColorFormat::RGB, ColorType::UnsignedByte, nullptr, BufferUsage::DynamicDraw);
+    framebuffer.setData(ColorFormat::RGB, ColorType::UnsignedByte, size, nullptr, BufferUsage::DynamicDraw);
     delete texture;
 
     Buffer::unbind(Buffer::Target::PixelPack);


### PR DESCRIPTION
Fix compilation with magnum configured to not use deprecated functions by using the non-deprecated "BufferImage2D::setData()" member function.
