### PR TITLE
triangle: Fix linking

### DIFF
--- a/src/triangle/CMakeLists.txt
+++ b/src/triangle/CMakeLists.txt
@@ -35,6 +35,6 @@ include_directories(${MAGNUM_INCLUDE_DIRS} ${MAGNUM_APPLICATION_INCLUDE_DIRS})
 
 add_executable(triangle TriangleExample.cpp)
 target_link_libraries(triangle
+    ${MAGNUM_APPLICATION_LIBRARIES}
     ${MAGNUM_LIBRARIES}
-    ${MAGNUM_SHADERS_LIBRARIES}
-    ${MAGNUM_APPLICATION_LIBRARIES})
+    ${MAGNUM_SHADERS_LIBRARIES})


### PR DESCRIPTION
Without this patch I get this error:

```
/usr/bin/ld: …/lib/libMagnum.so: undefined reference to symbol '_ZN7Corrade7Utility5DebugD1Ev'
…/lib/libCorradeUtility.so: error adding symbols: DSO missing from command line
```

The patch causes cmake to insert libCorradeUtility a second time in the link command line:
c++    -std=c++0x -Wall -Wextra -Wold-style-cast -Winit-self -Werror=return-type -Wmissing-declarations -pedantic -fvisibility=hidden -Wzero-as-null-pointer-constant -Wdouble-promotion    CMakeFiles/triangle.dir/TriangleExample.cpp.o  -o triangle -rdynamic …/lib/libMagnum.so …/lib/libCorradeUtility.so …/lib/libCorradePluginManager.so …/lib/libCorradeUtility.so -ldl -lGL …/lib/libMagnumShaders.so …/lib/libMagnumGlutApplication.a -lglut **{+…/lib/libCorradeUtility.so+}** …/lib/libCorradePluginManager.so -ldl -lGL …/lib/libMagnumShaders.so …/lib/libMagnumGlutApplication.a -lglut -Wl,-rpath,…/lib 

Here's how I build magnum from current git:

```
rm -rf ~/opt/magnum
cd ~/var/co/git/corrade
(mkcd build; cmake -DCMAKE_INSTALL_PREFIX=~/opt/magnum .. && make all install)
cd ~/var/co/git/magnum
(mkcd build; cmake -DCMAKE_INSTALL_PREFIX=~/opt/magnum -DWITH_GLUTAPPLICATION=ON -DWITH_SDL2APPLICATION=ON .. && LD_LIBRARY_PATH=~/opt/magnum/lib make all install)
cd ~/var/co/git/magnum-examples
# patch triangle CMakeLists
(rm -rf build; mkcd build; cmake -DWITH_PRIMITIVES=ON -DWITH_MOTIONBLUR=ON -DCMAKE_INSTALL_PREFIX=~/opt/magnum .. && LD_LIBRARY_PATH=~/opt/magnum/lib make)
```
