### PR TITLE
ovr: Adapt to LibOvrIntegration API changes.

### DIFF
--- a/src/ovr/HmdCamera.cpp
+++ b/src/ovr/HmdCamera.cpp
@@ -45,7 +45,7 @@ namespace Magnum { namespace Examples {
 using namespace LibOvrIntegration;
 
 HmdCamera::HmdCamera(Hmd& hmd, int eye, SceneGraph::AbstractObject3D& object): SceneGraph::Camera3D(object), _hmd(hmd) {
-    _textureSize = _hmd.getFovTextureSize(eye);
+    _textureSize = _hmd.fovTextureSize(eye);
 
     createEyeRenderTexture();
 
@@ -68,7 +68,7 @@ void HmdCamera::createEyeRenderTexture() {
     ColorType type = ColorType::UnsignedInt;
     TextureFormat format = TextureFormat::DepthComponent24;
 
-    if(Context::current()->isExtensionSupported<Extensions::GL::ARB::depth_buffer_float>()) {
+    if(Magnum::Context::current()->isExtensionSupported<Extensions::GL::ARB::depth_buffer_float>()) {
         format = TextureFormat::DepthComponent32F;
         type = ColorType::Float;
     }
@@ -90,7 +90,7 @@ void HmdCamera::draw(SceneGraph::DrawableGroup3D& group) {
     /* switch to eye render target and bind render textures */
     _framebuffer->bind();
 
-    _framebuffer->attachTexture(Framebuffer::ColorAttachment(0), _textureSet->getActiveTexture(), 0)
+    _framebuffer->attachTexture(Framebuffer::ColorAttachment(0), _textureSet->activeTexture(), 0)
                 .attachTexture(Framebuffer::BufferAttachment::Depth, *_depth, 0)
     /* clear with the standard grey so that at least that will be visible in case the scene is not
      * correctly set up. */

--- a/src/ovr/HmdCamera.h
+++ b/src/ovr/HmdCamera.h
@@ -51,7 +51,7 @@ class HmdCamera: public SceneGraph::Camera3D {
         /**
          * @return Reference to the texture set used for rendering.
          */
-        LibOvrIntegration::SwapTextureSet& getTextureSet() const {
+        LibOvrIntegration::SwapTextureSet& textureSet() const {
             return *_textureSet;
         }
 

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -199,7 +199,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
         /* projection matrix is set in the camera, since it requires some hmd-specific fov etc. */
         _cameras[eye].reset(new HmdCamera(*_hmd, eye, _eyes[eye]));
 
-        _layer->setColorTexture(eye, _cameras[eye]->getTextureSet());
+        _layer->setColorTexture(eye, _cameras[eye]->textureSet());
         _layer->setViewport(eye, {{}, _cameras[eye]->viewport()});
     }
 

--- a/src/picking/PickingExample.cpp
+++ b/src/picking/PickingExample.cpp
@@ -48,7 +48,7 @@
 #include <Magnum/Trade/MeshData3D.h>
 #include <Magnum/SceneGraph/Scene.h>
 #include <Magnum/SceneGraph/MatrixTransformation3D.h>
-#include <Magnum/SceneGraph/Camera3D.h>
+#include <Magnum/SceneGraph/Camera.h>
 #include <Magnum/SceneGraph/Drawable.h>
 
 using namespace Magnum;


### PR DESCRIPTION
Hi @mosra!

Corresponding to mosra/magnum-integration#5, here are the adaptations for the ovr example.

Greetings, 
Squareys.