### PR TITLE
Apdapt to Oculus SDK 0.6.0.1

### DIFF
--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -265,6 +265,8 @@ void OvrExample::keyPressEvent(KeyEvent& event) {
         if(!_hmd->isDebugHmd()) {
             _hmd->setPerformanceHudMode(_curPerfHudMode);
         }
+    } else if(event.key() == KeyEvent::Key::Esc) {
+        exit();
     }
 }
 

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -60,44 +60,42 @@
 #include <Magnum/LibOvrIntegration/Hmd.h>
 #include <Magnum/LibOvrIntegration/HmdEnum.h>
 
-namespace Magnum {
-
-namespace Examples {
+namespace Magnum { namespace Examples {
 
 using namespace LibOvrIntegration;
 
 /**
- * @brief The Application class of OVRExample.
+ * @brief The Application class of OvrExample.
  * @author Jonathan Hale (Squareys)
  */
 class OvrExample: public Platform::Application {
-public:
-    explicit OvrExample(const Arguments& arguments);
-    virtual ~OvrExample();
+    public:
+        explicit OvrExample(const Arguments& arguments);
+        virtual ~OvrExample();
 
-private:
-    void drawEvent() override;
+    private:
+        void drawEvent() override;
 
-    LibOvrIntegration::Context _ovrContext;
-    std::unique_ptr<Hmd> _hmd;
+        LibOvrIntegration::Context _ovrContext;
+        std::unique_ptr<Hmd> _hmd;
 
-    std::unique_ptr<Buffer> _indexBuffer, _vertexBuffer;
-    std::unique_ptr<Mesh> _mesh;
-    std::unique_ptr<Shaders::Phong> _shader;
+        std::unique_ptr<Buffer> _indexBuffer, _vertexBuffer;
+        std::unique_ptr<Mesh> _mesh;
+        std::unique_ptr<Shaders::Phong> _shader;
 
-    Scene3D _scene;
-    Object3D _cameraObject;
-    Object3D _eyes[2];
-    SceneGraph::DrawableGroup3D _drawables;
-    std::unique_ptr<HmdCamera> _cameras[2];
+        Scene3D _scene;
+        Object3D _cameraObject;
+        Object3D _eyes[2];
+        SceneGraph::DrawableGroup3D _drawables;
+        std::unique_ptr<HmdCamera> _cameras[2];
 
-    std::unique_ptr<Object3D> _cubes[4];
-    std::unique_ptr<CubeDrawable> _cubeDrawables[4];
+        std::unique_ptr<Object3D> _cubes[4];
+        std::unique_ptr<CubeDrawable> _cubeDrawables[4];
 
-    std::unique_ptr<Framebuffer> _mirrorFramebuffer;
-    Texture2D* _mirrorTexture;
+        std::unique_ptr<Framebuffer> _mirrorFramebuffer;
+        Texture2D* _mirrorTexture;
 
-    LayerEyeFov* _layer;
+        LayerEyeFov* _layer;
 };
 
 OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(arguments, nullptr),
@@ -243,7 +241,6 @@ void OvrExample::drawEvent() {
     redraw();
 }
 
-}
-}
+}}
 
 MAGNUM_APPLICATION_MAIN(Magnum::Examples::OvrExample)

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -127,7 +127,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
 
     Renderer::enable(Renderer::Feature::DepthTest);
 
-    _hmd->setEnabledCaps(HmdCapability::LowPersistence | HmdCapability::DynamicPrediction | HmdCapability::NoVSync);
+    _hmd->setEnabledCaps(HmdCapability::LowPersistence | HmdCapability::DynamicPrediction );
     _hmd->configureTracking(HmdTrackingCapability::Orientation | HmdTrackingCapability::MagYawCorrection |
                             HmdTrackingCapability::Position, {});
     _hmd->configureRendering();

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -73,6 +73,9 @@ class OvrExample: public Platform::Application {
         explicit OvrExample(const Arguments& arguments);
         virtual ~OvrExample();
 
+    protected:
+        virtual void keyPressEvent(KeyEvent& event) override;
+
     private:
         void drawEvent() override;
 
@@ -96,11 +99,13 @@ class OvrExample: public Platform::Application {
         Texture2D* _mirrorTexture;
 
         LayerEyeFov* _layer;
+
+        PerformanceHudMode _curPerfHudMode;
 };
 
 OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(arguments, nullptr),
     _indexBuffer(nullptr), _vertexBuffer(nullptr), _mesh(nullptr),
-    _shader(nullptr), _scene(), _cameraObject(&_scene)
+    _shader(nullptr), _scene(), _cameraObject(&_scene), _curPerfHudMode(PerformanceHudMode::Off)
 {
 
     /* connect to an Hmd, or create a debug hmd with DK2 type in case none is connected. */
@@ -239,6 +244,28 @@ void OvrExample::drawEvent() {
 
     swapBuffers();
     redraw();
+}
+
+void OvrExample::keyPressEvent(KeyEvent& event) {
+    if(event.key() == KeyEvent::Key::F11) {
+        /* toggle through the performance hud modes */
+        switch(_curPerfHudMode) {
+            case PerformanceHudMode::Off:
+                _curPerfHudMode = PerformanceHudMode::LatencyTiming;
+                break;
+            case PerformanceHudMode::LatencyTiming:
+                _curPerfHudMode = PerformanceHudMode::RenderTiming;
+                break;
+            case PerformanceHudMode::RenderTiming:
+                _curPerfHudMode = PerformanceHudMode::Off;
+                break;
+        }
+
+        /** libovr has a bug where performance hud will block the app when using a debug hmd */
+        if(!_hmd->isDebugHmd()) {
+            _hmd->setPerformanceHudMode(_curPerfHudMode);
+        }
+    }
 }
 
 }}


### PR DESCRIPTION
Hi @mosra !

the example required a minor change to compile with the adaptions of LibOvrIntegration to Oculus SDK 0.6.0.1 (https://github.com/mosra/magnum-integration/pull/7).

I also added the performance hud to the example, which only works for real devices because of an sdk bug for now, though.

Greetings, 
Squareys