### PR TITLE
Small fix for the ovr-example

### DIFF
--- a/src/ovr/HmdCamera.cpp
+++ b/src/ovr/HmdCamera.cpp
@@ -73,14 +73,11 @@ void HmdCamera::createEyeRenderTexture() {
         type = PixelType::Float;
     }
 
-    Image2D image(PixelFormat::DepthComponent, type, _textureSize, nullptr);
-
     _depth.reset(new Texture2D());
     _depth->setMinificationFilter(Sampler::Filter::Linear)
            .setMagnificationFilter(Sampler::Filter::Linear)
            .setWrapping(Sampler::Wrapping::ClampToEdge)
-           .setStorage(1, format, _textureSize)
-           .subImage(0, {{}, _textureSize}, image);
+           .setStorage(1, format, _textureSize);
 }
 
 void HmdCamera::draw(SceneGraph::DrawableGroup3D& group) {


### PR DESCRIPTION
Hi @mosra !

There was some unnecessary code which was causing an assertion failure with the new pixel storage support. This PR removes that.

Greetings, 
Squareys