### PR TITLE
ovr: Adapt to recent OvrIntegration changes. 

### DIFF
--- a/modules/FindOVR.cmake
+++ b/modules/FindOVR.cmake
@@ -18,7 +18,7 @@
 #
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016
 #             Vladimír Vondruš <mosra@centrum.cz>
-#   Copyright © 2015 Jonathan Hale <squareys@googlemail.com>
+#   Copyright © 2015, 2016 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -39,28 +39,59 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-set(LIBOVR_ROOT ${CMAKE_INSTALL_PREFIX})
-
 if(NOT OVR_SDK_ROOT)
-    message(WARNING "OVR_SDK_ROOT is not set. Will try to find headers and library in ${CMAKE_INSTALL_PREFIX}." )
-else()
-    set(LIBOVR_ROOT ${OVR_SDK_ROOT}/LibOVR)
+    find_path(OVR_SDK_ROOT OculusSDK)
+
+    if(OVR_SDK_ROOT)
+        set(OVR_SDK_ROOT "${OVR_SDK_ROOT}/OculusSDK")
+        message(STATUS "Found OculusSDK: ${OVR_SDK_ROOT}")
+    endif()
+
 endif()
+
+set(LIBOVR_ROOT ${OVR_SDK_ROOT}/LibOVR)
 
 # find include directory
 find_path(OVR_INCLUDE_DIR NAMES OVR_CAPI.h HINTS ${LIBOVR_ROOT}/Include)
 
 if(WIN32)
     if(MSVC)
-        find_library(OVR_LIBRARY NAMES LibOVR HINTS ${LIBOVR_ROOT}/Lib/Windows)
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            # compiling for 64 bit
+            set(_OVR_MSVC_ARCH "x64")
+        else()
+            # compiling for 32 bit
+            set(_OVR_MSVC_ARCH "Win32")
+        endif()
+
+        # select the correct library folder matching MSVC version
+        if (MSVC_VERSION GREATER 1800)
+            set(_OVR_MSVC_NAME "VS2015")
+        elseif (MSVC_VERSION GREATER 1700)
+            set(_OVR_MSVC_NAME "VS2013")
+        elseif (MSVC_VERSION GREATER 1600)
+            set(_OVR_MSVC_NAME "VS2012")
+        else()
+            set(_OVR_MSVC_NAME "VS2010")
+        endif()
+
+        find_library(OVR_LIBRARY NAMES LibOVR HINTS "${LIBOVR_ROOT}/Lib/Windows/${_OVR_MSVC_ARCH}/Release/${_OVR_MSVC_NAME}")
+
+        unset(_OVR_MSVC_ARCH)
+        unset(_OVR_MSVC_NAME)
     elseif(MINGW)
-        # linking against the MSVC dll with MinGW does not work directly. Instead, you need to
-        # link against a specific version. This will cause problems with newer oculus runtimes,
-        # though. (FIXME!)
-        # The clean way to link against libOVR, which seems to require the Windows DDK
-        find_library(OVR_LIBRARY NAMES LibOVRRT32_0_8.dll HINTS "C:/Windows/SysWOW64")
-        #find_library(OVR_LIBRARY NAMES LibOVR HINTS ${LIBOVR_ROOT}/Lib/Windows/Win32/Release/VS2012)
+        # we cannot link against the MSVC lib with MinGW. Instead, we link directly to the runtime DLL,
+        # which requires the Oculus runtime to be installed.
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            # compiling for 64 bit
+            find_library(OVR_LIBRARY NAMES LibOVRRT64_1.dll HINTS "C:/Program Files (x86)/Oculus/Support/oculus-runtime")
+        else()
+            # compiling for 32 bit
+            find_library(OVR_LIBRARY NAMES LibOVRRT32_1.dll HINTS "C:/Program Files (x86)/Oculus/Support/oculus-runtime")
+        endif()
     endif()
+else()
+    error("The Oculus SDK does not support ${CMAKE_SYSTEM_NAME}.")
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/src/ovr/HmdCamera.cpp
+++ b/src/ovr/HmdCamera.cpp
@@ -38,14 +38,14 @@
 #include <Magnum/Image.h>
 #include <Magnum/DefaultFramebuffer.h>
 
-#include <Magnum/OvrIntegration/Hmd.h>
+#include <Magnum/OvrIntegration/Session.h>
 
 namespace Magnum { namespace Examples {
 
 using namespace OvrIntegration;
 
-HmdCamera::HmdCamera(Hmd& hmd, int eye, SceneGraph::AbstractObject3D& object): SceneGraph::Camera3D(object), _hmd(hmd) {
-    _textureSize = _hmd.fovTextureSize(eye);
+HmdCamera::HmdCamera(Session& session, int eye, SceneGraph::AbstractObject3D& object): SceneGraph::Camera3D(object), _session(session) {
+    _textureSize = _session.fovTextureSize(eye);
 
     createEyeRenderTexture();
 
@@ -53,11 +53,11 @@ HmdCamera::HmdCamera(Hmd& hmd, int eye, SceneGraph::AbstractObject3D& object): S
 
     const Float near = 0.001f;
     const Float far = 100.0f;
-    setProjectionMatrix(_hmd.projectionMatrix(eye, near, far));
+    setProjectionMatrix(_session.projectionMatrix(eye, near, far));
 }
 
 void HmdCamera::createEyeRenderTexture() {
-    _textureSwapChain =_hmd.createTextureSwapChain(_textureSize);
+    _textureSwapChain =_session.createTextureSwapChain(_textureSize);
 
     /* create the framebuffer which will be used to render to the current texture
      * of the texture set later. */

--- a/src/ovr/HmdCamera.cpp
+++ b/src/ovr/HmdCamera.cpp
@@ -57,7 +57,7 @@ HmdCamera::HmdCamera(Hmd& hmd, int eye, SceneGraph::AbstractObject3D& object): S
 }
 
 void HmdCamera::createEyeRenderTexture() {
-    _textureSet =_hmd.createSwapTextureSet(TextureFormat::SRGB8Alpha8, _textureSize);
+    _textureSwapChain =_hmd.createTextureSwapChain(_textureSize);
 
     /* create the framebuffer which will be used to render to the current texture
      * of the texture set later. */
@@ -67,7 +67,7 @@ void HmdCamera::createEyeRenderTexture() {
     /* setup depth attachment */
     TextureFormat format = TextureFormat::DepthComponent24;
 
-    if(Magnum::Context::current()->isExtensionSupported<Extensions::GL::ARB::depth_buffer_float>()) {
+    if(Magnum::Context::current().isExtensionSupported<Extensions::GL::ARB::depth_buffer_float>()) {
         format = TextureFormat::DepthComponent32F;
     }
 
@@ -79,13 +79,10 @@ void HmdCamera::createEyeRenderTexture() {
 }
 
 void HmdCamera::draw(SceneGraph::DrawableGroup3D& group) {
-    /* increment to use next texture */
-    _textureSet->increment();
-
     /* switch to eye render target and bind render textures */
     _framebuffer->bind();
 
-    _framebuffer->attachTexture(Framebuffer::ColorAttachment(0), _textureSet->activeTexture(), 0)
+    _framebuffer->attachTexture(Framebuffer::ColorAttachment(0), _textureSwapChain->activeTexture(), 0)
                 .attachTexture(Framebuffer::BufferAttachment::Depth, *_depth, 0)
     /* clear with the standard grey so that at least that will be visible in case the scene is not
      * correctly set up. */
@@ -93,6 +90,9 @@ void HmdCamera::draw(SceneGraph::DrawableGroup3D& group) {
 
     /* render scene */
     SceneGraph::Camera3D::draw(group);
+
+    /* commit changes and use next texture in chain */
+    _textureSwapChain->commit();
 
     /* Reasoning for the next two lines, taken from the Oculus SDK examples code:
      * Without this, [during the next frame, this method] would bind a framebuffer with an

--- a/src/ovr/HmdCamera.h
+++ b/src/ovr/HmdCamera.h
@@ -51,8 +51,8 @@ class HmdCamera: public SceneGraph::Camera3D {
         /**
          * @return Reference to the texture set used for rendering.
          */
-        OvrIntegration::SwapTextureSet& textureSet() const {
-            return *_textureSet;
+        OvrIntegration::TextureSwapChain& textureSet() const {
+            return *_textureSwapChain;
         }
 
     private:
@@ -62,7 +62,7 @@ class HmdCamera: public SceneGraph::Camera3D {
         std::unique_ptr<Texture2D> _depth;
 
         OvrIntegration::Hmd& _hmd;
-        std::unique_ptr<OvrIntegration::SwapTextureSet> _textureSet;
+        std::unique_ptr<OvrIntegration::TextureSwapChain> _textureSwapChain;
 
         Vector2i _textureSize;
         std::unique_ptr<Framebuffer> _framebuffer;

--- a/src/ovr/HmdCamera.h
+++ b/src/ovr/HmdCamera.h
@@ -36,6 +36,12 @@
 
 namespace Magnum { namespace Examples {
 
+/**
+ * @brief Hmd camera
+ *
+ * Camera which renders a scene to a @ref OvrIntegration::TextureSwapChain.
+ * Handles framebuffer creation and activation.
+ */
 class HmdCamera: public SceneGraph::Camera3D {
     public:
         /**

--- a/src/ovr/HmdCamera.h
+++ b/src/ovr/HmdCamera.h
@@ -40,11 +40,11 @@ class HmdCamera: public SceneGraph::Camera3D {
     public:
         /**
          * @brief Constructor.
-         * @param hmd Hmd which this camera belongs to.
+         * @param session Oculus session for the HMD to create this camera for
          * @param eye Eye index associated with this camera. (0 for left, 1 for right eye)
          * @param object Object holding this feature.
          */
-        explicit HmdCamera(OvrIntegration::Hmd& hmd, const int eye, SceneGraph::AbstractObject3D& object);
+        explicit HmdCamera(OvrIntegration::Session& session, const int eye, SceneGraph::AbstractObject3D& object);
 
         void draw(SceneGraph::DrawableGroup3D& group) override;
 
@@ -61,7 +61,7 @@ class HmdCamera: public SceneGraph::Camera3D {
 
         std::unique_ptr<Texture2D> _depth;
 
-        OvrIntegration::Hmd& _hmd;
+        OvrIntegration::Session& _session;
         std::unique_ptr<OvrIntegration::TextureSwapChain> _textureSwapChain;
 
         Vector2i _textureSize;

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -129,7 +129,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
 
     /* setup mirroring of oculus sdk compositor results to a texture which can
        later be blitted onto the default framebuffer. */
-    _mirrorTexture = &_hmd->createMirrorTexture(TextureFormat::SRGB8, resolution);
+    _mirrorTexture = &_hmd->createMirrorTexture(resolution);
     _mirrorFramebuffer.reset(new Framebuffer(Range2Di::fromSize({}, resolution)));
     _mirrorFramebuffer->attachTexture(Framebuffer::ColorAttachment(0), *_mirrorTexture, 0)
                       .mapForRead(Framebuffer::ColorAttachment(0));
@@ -245,12 +245,15 @@ void OvrExample::keyPressEvent(KeyEvent& event) {
                 _curPerfHudMode = OvrIntegration::PerformanceHudMode::LatencyTiming;
                 break;
             case OvrIntegration::PerformanceHudMode::LatencyTiming:
-                _curPerfHudMode = OvrIntegration::PerformanceHudMode::RenderTiming;
+                _curPerfHudMode = OvrIntegration::PerformanceHudMode::AppRenderTiming;
                 break;
-            case OvrIntegration::PerformanceHudMode::RenderTiming:
-                _curPerfHudMode = OvrIntegration::PerformanceHudMode::PerfHeadroom;
+            case OvrIntegration::PerformanceHudMode::AppRenderTiming:
+                _curPerfHudMode = OvrIntegration::PerformanceHudMode::CompRenderTiming;
                 break;
-            case OvrIntegration::PerformanceHudMode::PerfHeadroom:
+            case OvrIntegration::PerformanceHudMode::CompRenderTiming:
+                _curPerfHudMode = OvrIntegration::PerformanceHudMode::PerfSummary;
+                break;
+            case OvrIntegration::PerformanceHudMode::PerfSummary:
                 _curPerfHudMode = OvrIntegration::PerformanceHudMode::VersionInfo;
                 break;
             case OvrIntegration::PerformanceHudMode::VersionInfo:

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -52,7 +52,7 @@
 #include <Magnum/Trade/MeshData3D.h>
 #include <Magnum/OvrIntegration/OvrIntegration.h>
 #include <Magnum/OvrIntegration/Context.h>
-#include <Magnum/OvrIntegration/Hmd.h>
+#include <Magnum/OvrIntegration/Session.h>
 #include <Magnum/OvrIntegration/HmdEnum.h>
 
 #include "Types.h"
@@ -70,7 +70,7 @@ class OvrExample: public Platform::Application {
         void keyPressEvent(KeyEvent& event) override;
 
         OvrIntegration::Context _ovrContext;
-        std::unique_ptr<OvrIntegration::Hmd> _hmd;
+        std::unique_ptr<OvrIntegration::Session> _session;
 
         std::unique_ptr<Buffer> _indexBuffer, _vertexBuffer;
         std::unique_ptr<Mesh> _mesh;
@@ -101,12 +101,11 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
     _curDebugHudStereoMode(OvrIntegration::DebugHudStereoMode::Off),
     _enableMirroring(true)
 {
-    /* connect to an HMD, or create a debug HMD with DK2 type in case none is
-       connected */
-    _hmd = _ovrContext.createHmd();
+    /* Connect to an active Oculus session */
+    _session = _ovrContext.createSession();
 
     /* get the hmd display resolution */
-    Vector2i resolution = _hmd->resolution() / 2;
+    Vector2i resolution = _session->resolution() / 2;
 
     /* create a context with the HMD display resolution */
     Configuration conf;
@@ -125,11 +124,11 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
     Renderer::enable(Renderer::Feature::DepthTest);
     Renderer::enable(Renderer::Feature::FramebufferSRGB);
 
-    _hmd->configureRendering();
+    _session->configureRendering();
 
     /* setup mirroring of oculus sdk compositor results to a texture which can
        later be blitted onto the default framebuffer. */
-    _mirrorTexture = &_hmd->createMirrorTexture(resolution);
+    _mirrorTexture = &_session->createMirrorTexture(resolution);
     _mirrorFramebuffer.reset(new Framebuffer(Range2Di::fromSize({}, resolution)));
     _mirrorFramebuffer->attachTexture(Framebuffer::ColorAttachment(0), *_mirrorTexture, 0)
                       .mapForRead(Framebuffer::ColorAttachment(0));
@@ -183,7 +182,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
 
     /* setup compositor layers */
     _layer = &_ovrContext.compositor().addLayerEyeFov();
-    _layer->setFov(*_hmd.get());
+    _layer->setFov(*_session.get());
     _layer->setHighQuality(true);
 
     /* setup cameras */
@@ -192,7 +191,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
 
     for(int eye = 0; eye < 2; ++eye) {
         /* projection matrix is set in the camera, since it requires some hmd-specific fov etc. */
-        _cameras[eye].reset(new HmdCamera(*_hmd, eye, _eyes[eye]));
+        _cameras[eye].reset(new HmdCamera(*_session, eye, _eyes[eye]));
 
         _layer->setColorTexture(eye, _cameras[eye]->textureSet());
         _layer->setViewport(eye, {{}, _cameras[eye]->viewport()});
@@ -201,7 +200,7 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
 
 void OvrExample::drawEvent() {
     /* get orientation and position of the hmd. */
-    std::array<DualQuaternion, 2> poses = _hmd->pollEyePoses().eyePoses();
+    std::array<DualQuaternion, 2> poses = _session->pollEyePoses().eyePoses();
 
     /* draw the scene for both cameras */
     for(int eye = 0; eye < 2; ++eye) {
@@ -212,10 +211,10 @@ void OvrExample::drawEvent() {
     }
 
     /* set the layers eye poses to the poses chached in the _hmd. */
-    _layer->setRenderPoses(*_hmd.get());
+    _layer->setRenderPoses(*_session.get());
 
     /* let the libOVR sdk compositor do its magic! */
-    _ovrContext.compositor().submitFrame(*_hmd.get());
+    _ovrContext.compositor().submitFrame(*_session.get());
 
     if(_enableMirroring) {
         /* blit mirror texture to defaultFramebuffer. */
@@ -229,7 +228,7 @@ void OvrExample::drawEvent() {
         swapBuffers();
     }
 
-    if(_hmd->isDebugHmd()) {
+    if(_session->isDebugHmd()) {
         /* provide some rotation, but only without real devices to avoid vr sickness ;) */
         _cameraObject.rotateY(Deg(0.1f));
     }
@@ -261,7 +260,7 @@ void OvrExample::keyPressEvent(KeyEvent& event) {
                 break;
         }
 
-        _hmd->setPerformanceHudMode(_curPerfHudMode);
+        _session->setPerformanceHudMode(_curPerfHudMode);
     } else if(event.key() == KeyEvent::Key::F12) {
         /* toggle through the debug hud stereo modes */
         switch(_curDebugHudStereoMode) {
@@ -279,7 +278,7 @@ void OvrExample::keyPressEvent(KeyEvent& event) {
                 break;
         }
 
-        _hmd->setDebugHudStereoMode(_curDebugHudStereoMode);
+        _session->setDebugHudStereoMode(_curDebugHudStereoMode);
     } else if(event.key() == KeyEvent::Key::M) {
         /* toggle mirroring */
         _enableMirroring = !_enableMirroring;


### PR DESCRIPTION
Hi everybody!

Since OvrIntegration is being adapted to Oculus SDK 1.3.0 (see the PR https://github.com/mosra/magnum-integration/pull/12) which resulted in API changes, these now also are reflected in the example with this pullrequest.

TODOs:
 - [x] Wait for merge of https://github.com/mosra/magnum-integration/pull/12

Regards,
Jonathan (Squareys)