### PR TITLE
Fix include of OvrIntegration enums.

### DIFF
--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -102,6 +102,12 @@ OvrExample::OvrExample(const Arguments& arguments) : Platform::Application(argum
     /* Connect to an active Oculus session */
     _session = _ovrContext.createSession();
 
+    if(!_session) {
+        Error() << "No HMD connected.";
+        exit();
+        return;
+    }
+
     /* Get the HMD display resolution */
     const Vector2i resolution = _session->resolution() / 2;
 

--- a/src/ovr/OvrExample.cpp
+++ b/src/ovr/OvrExample.cpp
@@ -52,7 +52,7 @@
 #include <Magnum/OvrIntegration/OvrIntegration.h>
 #include <Magnum/OvrIntegration/Context.h>
 #include <Magnum/OvrIntegration/Session.h>
-#include <Magnum/OvrIntegration/HmdEnum.h>
+#include <Magnum/OvrIntegration/Enums.h>
 
 #include "Types.h"
 #include "HmdCamera.h"


### PR DESCRIPTION
Hi @mosra !

Here is the requested fix for the `HmdEnums.h` missing include.

Regards, Jonathan.

PS: I snuck in another enhancement ;)