### PR TITLE
Port audio example to emscripten

### DIFF
--- a/src/audio/AudioExample.cpp
+++ b/src/audio/AudioExample.cpp
@@ -58,6 +58,14 @@
 
 #include "configure.h"
 
+#ifdef MAGNUM_BUILD_STATIC
+/* Import plugins in static build */
+static int importStaticPlugins() {
+    CORRADE_PLUGIN_IMPORT(WavAudioImporter)
+    return 0;
+} CORRADE_AUTOMATIC_INITIALIZER(importStaticPlugins)
+#endif
+
 namespace Magnum { namespace Examples {
 
 using namespace Magnum::SceneGraph;
@@ -73,7 +81,7 @@ class AudioExample: public Platform::Application {
     private:
         void drawEvent() override;
 
-        void keyPressEvent(KeyEvent& event);
+        void keyPressEvent(KeyEvent& event) override;
 
         DebugTools::ResourceManager _manager;
 
@@ -102,7 +110,12 @@ AudioExample::AudioExample(const Arguments& arguments):
     Platform::Application{arguments, NoCreate},
     /* Create the audio context. Without this, sound will not be initialized:
        Needs to be done before Playables and Sources are initialized. */
+#ifndef CORRADE_TARGET_EMSCRIPTEN
     _context(Audio::Context::Configuration().setHrtf(Audio::Context::Configuration::Hrtf::Enabled)),
+#else
+    /* No Hrtf support on emscripten :( */
+    _context(),
+#endif
     _sourceRig(&_scene),
     _sourceObject(&_sourceRig),
     _cameraObject(&_scene),
@@ -169,7 +182,6 @@ AudioExample::AudioExample(const Arguments& arguments):
 
     /* Loop at 60 Hz max */
     setSwapInterval(1);
-    setMinimalLoopPeriod(16);
 }
 
 void AudioExample::drawEvent() {

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -46,6 +46,10 @@ find_package(Magnum REQUIRED
     SceneGraph
     Sdl2Application)
 
+if(CORRADE_TARGET_NACL OR CORRADE_TARGET_EMSCRIPTEN OR CORRADE_TARGET_ANDROID OR CORRADE_TARGET_IOS)
+    find_package(Magnum REQUIRED WavAudioImporter)
+endif()
+
 set_directory_properties(PROPERTIES CORRADE_USE_PEDANTIC_FLAGS ON)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure.h.cmake
@@ -64,5 +68,19 @@ target_link_libraries(magnum-audio
     Magnum::Magnum
     Magnum::SceneGraph)
 
-install(TARGETS magnum-audio DESTINATION ${MAGNUM_BINARY_INSTALL_DIR})
-install(FILES README.md DESTINATION ${MAGNUM_DATA_INSTALL_DIR}/examples RENAME README-audio.md)
+if(CORRADE_TARGET_NACL OR CORRADE_TARGET_EMSCRIPTEN OR CORRADE_TARGET_ANDROID OR CORRADE_TARGET_IOS)
+    target_link_libraries(magnum-audio Magnum::WavAudioImporter)
+endif()
+
+
+# Installation for Emscripten
+if(CORRADE_TARGET_EMSCRIPTEN)
+    install(FILES audio-emscripten.html DESTINATION ${CMAKE_INSTALL_PREFIX})
+    install(TARGETS magnum-audio DESTINATION ${CMAKE_INSTALL_PREFIX})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/magnum-audio.js.mem DESTINATION ${CMAKE_INSTALL_PREFIX} OPTIONAL)
+
+# Installation for desktop
+elseif(NOTCORRADE_TARGET_IOS AND NOT CORRADE_TARGET_NACL)
+    install(TARGETS magnum-audio DESTINATION ${MAGNUM_BINARY_INSTALL_DIR})
+    install(FILES README.md DESTINATION ${MAGNUM_DATA_INSTALL_DIR}/examples RENAME README-audio.md)
+endif()

--- a/src/audio/audio-emscripten.html
+++ b/src/audio/audio-emscripten.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Magnum Audio Example</title>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="WebApplication.css" />
+  </head>
+  <body>
+    <h1>Magnum Audio Example</h1>
+    <div id="listener">
+      <canvas id="module"></canvas>
+      <div id="status">Initialization...</div>
+      <div id="statusDescription"></div>
+      <script src="EmscriptenApplication.js"></script>
+      <script async="async" src="magnum-audio.js"></script>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Hi @mosra !

I promised I would port the audio example to emscripten and here you go. This will work without the [pullrequest to magnum](https://github.com/mosra/magnum/pull/216), so you can merge in any order you desire!

The sound sadly is neither binaural (HRTF) nor uses stereo panning. I guess the emscripten AL implementation is pretty basic...

Cheers, Jonathan.