### PR TITLE
webvr: touchstart is not sufficient as a user gesture

### DIFF
--- a/doc/webvr.dox
+++ b/doc/webvr.dox
@@ -37,10 +37,7 @@ This example is a basic demonstration of how to use the
 with Magnum.
 
 For the full experience, this example requires a WebVR 1.1 capable browser and
-a VR headset. Note that Emscripten currently has
-[a pending API change](https://github.com/kripken/emscripten/pull/5640), the
-code of this example is modified to support both current and the next API
-version.
+a VR headset. You may need to enable WebVR support explicitly on your browser.
 
 @m_div{m-button m-primary} <a href="http://magnum.graphics/showcase/webvr/">@m_div{m-big} Live web demo @m_enddiv @m_div{m-small} uses WebAssembly & WebGL @m_enddiv </a> @m_enddiv
 

--- a/src/webvr/WebVrExample.cpp
+++ b/src/webvr/WebVrExample.cpp
@@ -89,7 +89,7 @@ EM_BOOL clickCallback(int eventType, const EmscriptenMouseEvent* e, void* app) {
 
 /* Touch callback for requesting present on mobile */
 EM_BOOL touchCallback(int eventType, const EmscriptenTouchEvent* e, void* app) {
-    if(!e || eventType != EMSCRIPTEN_EVENT_TOUCHSTART) return EM_FALSE;
+    if(!e || eventType != EMSCRIPTEN_EVENT_TOUCHEND) return EM_FALSE;
 
     static_cast<WebVrExample*>(app)->onClick();
     return EM_FALSE;
@@ -193,7 +193,7 @@ void WebVrExample::vrReady() {
 
     /* Set callbacks for getting present permission for the VR display */
     emscripten_set_click_callback("#canvas", this, true, clickCallback);
-    emscripten_set_touchstart_callback("#canvas", this, true, touchCallback);
+    emscripten_set_touchend_callback("#canvas", this, true, touchCallback);
 
     _vrInitialized = true;
 }


### PR DESCRIPTION
Hi @mosra !

I finally solved the issue of the webvr example on mobile devices.

Also make sure to enable webvr support in your browser (docs are updated). Even on mobile devices this is required, except if a API token from google has been aquired for your origin (e.g. magnum.graphics, see https://docs.google.com/forms/d/e/1FAIpQLSfO0_ptFl8r8G0UFhT0xhV17eabG-erUWBDiKSRDTqEZ_9ULQ/viewform)

Cheers, Jonathan.