### PR TITLE
modules: Make FindSDL2.cmake also find debug libraries

### DIFF
--- a/modules/FindSDL2.cmake
+++ b/modules/FindSDL2.cmake
@@ -10,6 +10,8 @@
 # Additionally these variables are defined for internal usage:
 #
 #  SDL2_LIBRARY             - SDL2 library
+#  SDL2_LIBRARY_DEBUG       - SDL2 debug library
+#  SDL2_LIBRARY_RELEASE     - SDL2 release library
 #  SDL2_INCLUDE_DIR         - Root include dir
 #
 
@@ -50,15 +52,21 @@ else()
         set(_SDL_LIBRARY_PATH_SUFFIX lib/x86)
     endif()
 
-    find_library(SDL2_LIBRARY
+    find_library(SDL2_LIBRARY_RELEASE
         # Compiling SDL2 from scratch on macOS creates dead libSDL2.so symlink
         # which CMake somehow prefers before the SDL2-2.0.dylib file. Making
         # the dylib first so it is preferred.
         NAMES SDL2-2.0 SDL2
         PATH_SUFFIXES ${_SDL_LIBRARY_PATH_SUFFIX})
+    find_library(SDL2_LIBRARY_DEBUG
+        NAMES SDL2d
+        PATH_SUFFIXES ${_SDL_LIBRARY_PATH_SUFFIX})
     set(SDL2_LIBRARY_NEEDED SDL2_LIBRARY)
     set(_SDL2_PATH_SUFFIXES SDL2)
 endif()
+
+include(SelectLibraryConfigurations)
+select_library_configurations(SDL2)
 
 # Include dir
 find_path(SDL2_INCLUDE_DIR
@@ -120,10 +128,19 @@ if(NOT TARGET SDL2::SDL2)
 
         # Work around BUGGY framework support on macOS
         # https://cmake.org/Bug/view.php?id=14105
-        if(CORRADE_TARGET_APPLE AND ${SDL2_LIBRARY} MATCHES "\\.framework$")
-            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION ${SDL2_LIBRARY}/SDL2)
+        if(CORRADE_TARGET_APPLE AND SDL2_LIBRARY_RELEASE MATCHES "\\.framework$")
+            set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_RELEASE ${SDL2_LIBRARY_RELEASE}/SDL2)
         else()
-            set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION ${SDL2_LIBRARY})
+            if(SDL2_LIBRARY_RELEASE)
+                set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+                set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_RELEASE ${SDL2_LIBRARY_RELEASE})
+            endif()
+
+            if(SDL2_LIBRARY_DEBUG)
+                set_property(TARGET SDL2::SDL2 APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+                set_property(TARGET SDL2::SDL2 PROPERTY IMPORTED_LOCATION_DEBUG ${SDL2_LIBRARY_DEBUG})
+            endif()
         endif()
 
         # Link frameworks on iOS


### PR DESCRIPTION
Hi @mosra !

As discussed in #42 , here's the PR that fixed the find module to also find the debug libs so that they are properly copied in vcpkg builds.

Cheers, Jonathan