### PR TITLE
FluidSimulation3D example: fix bug, and change header guards

### DIFF
--- a/src/fluidsimulation3d/CMakeLists.txt
+++ b/src/fluidsimulation3d/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(magnum-fluidsimulation3d WIN32
     FluidSimulation3DExample.cpp
     TaskScheduler.h
     ThreadPool.h
+    DrawableObjects/WireframeObjects.h
     DrawableObjects/FlatShadeObject.h
     DrawableObjects/ParticleGroup.h
     DrawableObjects/ParticleGroup.cpp

--- a/src/fluidsimulation3d/DrawableObjects/FlatShadeObject.h
+++ b/src/fluidsimulation3d/DrawableObjects/FlatShadeObject.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_DrawableObjects_FlatShadeObject_h
-#define Magnum_Examples_DrawableObjects_FlatShadeObject_h
+#ifndef Magnum_Examples_FluidSimulation3D_DrawableObjects_FlatShadeObject_h
+#define Magnum_Examples_FluidSimulation3D_DrawableObjects_FlatShadeObject_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/DrawableObjects/ParticleGroup.h
+++ b/src/fluidsimulation3d/DrawableObjects/ParticleGroup.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_DrawableObjects_ParticleGroup_h
-#define Magnum_Examples_DrawableObjects_ParticleGroup_h
+#ifndef Magnum_Examples_FluidSimulation3D_DrawableObjects_ParticleGroup_h
+#define Magnum_Examples_FluidSimulation3D_DrawableObjects_ParticleGroup_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/DrawableObjects/WireframeObjects.h
+++ b/src/fluidsimulation3d/DrawableObjects/WireframeObjects.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_DrawableObjects_WireframeObjects_h
-#define Magnum_Examples_DrawableObjects_WireframeObjects_h
+#ifndef Magnum_Examples_FluidSimulation3D_DrawableObjects_WireframeObjects_h
+#define Magnum_Examples_FluidSimulation3D_DrawableObjects_WireframeObjects_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/FluidSimulation3DExample.cpp
+++ b/src/fluidsimulation3d/FluidSimulation3DExample.cpp
@@ -153,7 +153,7 @@ FluidSimulation3DExample::FluidSimulation3DExample(const Arguments& arguments): 
         Utility::Resource rs{"data"};
         Containers::ArrayView<const char> font = rs.getRaw("SourceSansPro-Regular.ttf");
         ImGui::GetIO().Fonts->AddFontFromMemoryTTF(
-            const_cast<char*>(font.data()), font.size(), 16.0f*framebufferSize().x()/size.x(), &fontConfig);
+            const_cast<char*>(font.data()), Int(font.size()), 16.0f*framebufferSize().x()/size.x(), &fontConfig);
 
         _imGuiContext = ImGuiIntegration::Context(*ImGui::GetCurrentContext(),
             Vector2{windowSize()}/dpiScaling(), windowSize(), framebufferSize());
@@ -471,11 +471,11 @@ void FluidSimulation3DExample::showMenu() {
             if(ImGui::Combo("Color Mode", &colorMode, items, 3))
                 _drawableParticles->setColorMode(ParticleSphereShader::ColorMode(colorMode));
             if(colorMode == 0) { /* Uniform color */
-			    static Color3 color = _drawableParticles->diffuseColor();
+                static Color3 color = _drawableParticles->diffuseColor();
                 if(ImGui::ColorEdit3("Diffuse Color", color.data())) {
-					_drawableParticles->setDiffuseColor(color);
-				}
-			}
+                    _drawableParticles->setDiffuseColor(color);
+                }
+            }
         }
         ImGui::InputFloat3("Light Direction", _drawableParticles->lightDirection().data());
         ImGui::PopID();

--- a/src/fluidsimulation3d/FluidSimulation3DExample.cpp
+++ b/src/fluidsimulation3d/FluidSimulation3DExample.cpp
@@ -470,8 +470,12 @@ void FluidSimulation3DExample::showMenu() {
             static Int colorMode = 1;
             if(ImGui::Combo("Color Mode", &colorMode, items, 3))
                 _drawableParticles->setColorMode(ParticleSphereShader::ColorMode(colorMode));
-            if(colorMode == 0) /* Uniform color */
-                ImGui::ColorEdit3("Diffuse Color", _drawableParticles->diffuseColor().data());
+            if(colorMode == 0) { /* Uniform color */
+			    static Color3 color = _drawableParticles->diffuseColor();
+                if(ImGui::ColorEdit3("Diffuse Color", color.data())) {
+					_drawableParticles->setDiffuseColor(color);
+				}
+			}
         }
         ImGui::InputFloat3("Light Direction", _drawableParticles->lightDirection().data());
         ImGui::PopID();

--- a/src/fluidsimulation3d/FluidSimulation3DExample.cpp
+++ b/src/fluidsimulation3d/FluidSimulation3DExample.cpp
@@ -463,7 +463,7 @@ void FluidSimulation3DExample::showMenu() {
     ImGui::Spacing();
 
     /* Rendering parameters */
-    if(ImGui::CollapsingHeader("Particle Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if(ImGui::TreeNodeEx("Particle Rendering", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::PushID("Particle Rendering");
         {
             constexpr const char* items[] = {"Uniform", "Ramp by ID", "Random"};
@@ -482,19 +482,21 @@ void FluidSimulation3DExample::showMenu() {
             _drawableParticles->setLightDirection(lightDir);
         }
         ImGui::PopID();
+        ImGui::TreePop();
     }
     ImGui::Spacing();
     ImGui::Separator();
     ImGui::Spacing();
 
     /* Simulation parameters */
-    if(ImGui::CollapsingHeader("Simulation", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if(ImGui::TreeNodeEx("Simulation", ImGuiTreeNodeFlags_DefaultOpen)) {
         ImGui::PushID("Simulation");
         ImGui::InputFloat("Stiffness", &_fluidSolver->simulationParameters().stiffness);
         ImGui::SliderFloat("Viscosity",   &_fluidSolver->simulationParameters().viscosity,           0.0f, 1.0f);
         ImGui::SliderFloat("Restitution", &_fluidSolver->simulationParameters().boundaryRestitution, 0.0f, 1.0f);
         ImGui::Checkbox("Dynamic Boundary", &_dynamicBoundary);
         ImGui::PopID();
+        ImGui::TreePop();
     }
     ImGui::Spacing();
     ImGui::Separator();

--- a/src/fluidsimulation3d/FluidSimulation3DExample.cpp
+++ b/src/fluidsimulation3d/FluidSimulation3DExample.cpp
@@ -477,7 +477,10 @@ void FluidSimulation3DExample::showMenu() {
                 }
             }
         }
-        ImGui::InputFloat3("Light Direction", _drawableParticles->lightDirection().data());
+        static Vector3 lightDir = _drawableParticles->lightDirection();
+        if(ImGui::InputFloat3("Light Direction", lightDir.data())) {
+            _drawableParticles->setLightDirection(lightDir);
+        }
         ImGui::PopID();
     }
     ImGui::Spacing();

--- a/src/fluidsimulation3d/SPH/DomainBox.cpp
+++ b/src/fluidsimulation3d/SPH/DomainBox.cpp
@@ -29,10 +29,9 @@
  */
 
 #include "DomainBox.h"
+#include "TaskScheduler.h"
 
 #include <random>
-
-#include "TaskScheduler.h"
 
 namespace Magnum { namespace Examples {
 

--- a/src/fluidsimulation3d/SPH/DomainBox.h
+++ b/src/fluidsimulation3d/SPH/DomainBox.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_SPH_DomainBox_h
-#define Magnum_Examples_SPH_DomainBox_h
+#ifndef Magnum_Examples_FluidSimulation3D_SPH_DomainBox_h
+#define Magnum_Examples_FluidSimulation3D_SPH_DomainBox_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/SPH/SPHKernels.h
+++ b/src/fluidsimulation3d/SPH/SPHKernels.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_SPH_SPHKernels_h
-#define Magnum_Examples_SPH_SPHKernels_h
+#ifndef Magnum_Examples_FluidSimulation3D_SPH_SPHKernels_h
+#define Magnum_Examples_FluidSimulation3D_SPH_SPHKernels_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/SPH/SPHSolver.cpp
+++ b/src/fluidsimulation3d/SPH/SPHSolver.cpp
@@ -29,7 +29,6 @@
  */
 
 #include "SPHSolver.h"
-
 #include "TaskScheduler.h"
 
 namespace Magnum { namespace Examples {

--- a/src/fluidsimulation3d/SPH/SPHSolver.h
+++ b/src/fluidsimulation3d/SPH/SPHSolver.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_SPH_SPHSolver_h
-#define Magnum_Examples_SPH_SPHSolver_h
+#ifndef Magnum_Examples_FluidSimulation3D_SPH_SPHSolver_h
+#define Magnum_Examples_FluidSimulation3D_SPH_SPHSolver_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/Shaders/ParticleSphereShader.h
+++ b/src/fluidsimulation3d/Shaders/ParticleSphereShader.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_Shaders_ParticleSphereShader_h
-#define Magnum_Examples_Shaders_ParticleSphereShader_h
+#ifndef Magnum_Examples_FluidSimulation3D_Shaders_ParticleSphereShader_h
+#define Magnum_Examples_FluidSimulation3D_Shaders_ParticleSphereShader_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/TaskScheduler.h
+++ b/src/fluidsimulation3d/TaskScheduler.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_TaskScheduler_h
-#define Magnum_Examples_TaskScheduler_h
+#ifndef Magnum_Examples_FluidSimulation3D_TaskScheduler_h
+#define Magnum_Examples_FluidSimulation3D_TaskScheduler_h
 /*
     This file is part of Magnum.
 

--- a/src/fluidsimulation3d/ThreadPool.h
+++ b/src/fluidsimulation3d/ThreadPool.h
@@ -36,6 +36,7 @@
 #include <condition_variable>
 #include <functional>
 #include <atomic>
+
 #include <Magnum/Math/Functions.h>
 
 namespace Magnum { namespace Examples {
@@ -46,8 +47,8 @@ namespace Magnum { namespace Examples {
 class ThreadPool {
     public:
         ThreadPool() {
-            const Int maxNumThreads = std::thread::hardware_concurrency();
-            std::size_t nWorkers = maxNumThreads > 1 ? maxNumThreads - 1 : 0;
+            const Int maxNumThreads = Int(std::thread::hardware_concurrency());
+            std::size_t nWorkers = std::size_t(maxNumThreads > 1 ? maxNumThreads - 1 : 0);
 
             _threadTaskReady.resize(nWorkers, 0);
             _tasks.resize(nWorkers + 1);

--- a/src/fluidsimulation3d/ThreadPool.h
+++ b/src/fluidsimulation3d/ThreadPool.h
@@ -1,5 +1,5 @@
-#ifndef Magnum_Examples_ThreadPool_h
-#define Magnum_Examples_ThreadPool_h
+#ifndef Magnum_Examples_FluidSimulation3D_ThreadPool_h
+#define Magnum_Examples_FluidSimulation3D_ThreadPool_h
 /*
     This file is part of Magnum.
 


### PR DESCRIPTION
Hi @mosra,

I did some changes for the FluidSimulation example:
- Fixed a bug: the particle color cannot be changed.
- Fixed a bug: the light direction cannot be changed.
- I changed header guards of the *.h files, adding example name. This is necessary if we have different examples having files with the same file names.
- Fixed some warnings.
- Improve menu.

Also, the link in the example page (https://doc.magnum.graphics/magnum/examples-fluidsimulation3d.html):
```
Full source code is linked below and also available in the magnum-examples GitHub repository.
```
is wrong.