### PR TITLE
Update ArcBallCamera.h

### DIFF
--- a/src/arcball/ArcBallCamera.h
+++ b/src/arcball/ArcBallCamera.h
@@ -54,7 +54,7 @@ class ArcBallCamera: public ArcBall {
             (*(_camera = new SceneGraph::Camera3D{*cameraObject}))
                 .setAspectRatioPolicy(SceneGraph::AspectRatioPolicy::Extend)
                 .setProjectionMatrix(Matrix4::perspectiveProjection(
-                    fov, Vector2{windowSize}.aspectRatio(), 0.01f, 100.0f))
+                    fov, Vector2{windowSize}.aspectRatio(), 0.01f, 1000.0f))
                 .setViewport(viewportSize);
 
             /* Save the abstract transformation interface and initialize the


### PR DESCRIPTION
Change the frustum clip distance. The current 'far' clip is too small, thus some large objects can be cut off.