### PR TITLE
Box2D: Support for July 2020 version

### DIFF
--- a/modules/FindBox2D.cmake
+++ b/modules/FindBox2D.cmake
@@ -39,11 +39,12 @@
 #
 
 # Library
-find_library(BOX2D_LIBRARY NAMES Box2D)
+find_library(BOX2D_LIBRARY NAMES Box2D box2d)
 
 # Include dir
 find_path(BOX2D_INCLUDE_DIR
-    NAMES Box2D/Box2D.h)
+    NAMES Box2D/Box2D.h
+          box2d/box2d.h)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Box2D DEFAULT_MSG

--- a/src/box2d/Box2DExample.cpp
+++ b/src/box2d/Box2DExample.cpp
@@ -28,7 +28,20 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/* Latest Box2D release from 2014 uses mixed case, current master (2020) uses
+   lowercase */
+#ifdef __has_include
+#if __has_include(<box2d/box2d.h>)
+#include <box2d/box2d.h>
+#else
 #include <Box2D/Box2D.h>
+#endif
+/* If the compiler doesn't have __has_include, assume it's extremely old, and 
+   thus an extremely old Box2D is more likely as well */
+#else
+#include <Box2D/Box2D.h>
+#endif
+
 #include <Corrade/Containers/GrowableArray.h>
 #include <Corrade/Utility/Arguments.h>
 #include <Magnum/GL/Context.h>


### PR DESCRIPTION
The latest release (as of this writing) of Box2D is [from 2014](https://github.com/erincatto/box2d/releases) and uses mixed-case `Box2D.h` whereas the newer one is all lowercase `box2d.h`. This change adds support for the newer version, without breaking compatibility with the older one.

Box2D also no longer provides a CMake `install()` directive, which can be gotten around like this.

From..

```bash
# Version 2014
git clone https://github.com/erincatto/box2d --branch v2.3.1
cd box2d
mkdir build && cd build
cmake ..
cmake --build . --target install
```

To..

```bash
# Version 2020
git clone https://github.com/erincatto/box2d
cd box2d
git checkout 1025f9a
mkdir build && cd build
cmake ..
cmake --build .
cp src/box2d.bc <your-prefix>/lib/
cp -R ../include/box2d <your-prefix>/include/box2d
```