### PR TITLE
Properly remove invalid points from nodes.

### DIFF
--- a/src/octree/LooseOctree.h
+++ b/src/octree/LooseOctree.h
@@ -229,6 +229,9 @@ class LooseOctree {
         /* Count the maximum number of points stored in a tree node */
         std::size_t maxNumPointInNodes() const;
 
+        /* Count total number of points stored in a tree node */
+        std::size_t totalPointsInNodes() const;
+
         /* True rebuilds the tree from scratch in every update, false
            incrementally updates from the current state */
         void setAlwaysRebuild(const bool alwaysRebuild) {

--- a/src/octree/OctreeExample.cpp
+++ b/src/octree/OctreeExample.cpp
@@ -244,8 +244,15 @@ void OctreeExample::drawEvent() {
 
         movePoints();
 
-        if(_collisionDetectionByOctree)
+        if(_collisionDetectionByOctree) {
             _octree->update();
+#if !defined(NDEBUG)
+            /* We never move points outside of Octree's bounding box,
+               hence all spheres should be in the tree at any given point of time */
+            CORRADE_ASSERT(_octree->totalPointsInNodes() == _spherePositions.size()
+                , "Broken Octee invariant: points count missmatch.", );
+#endif
+        }
     }
 
     /* Update camera before drawing instances */


### PR DESCRIPTION
Hello.

Was looking at Octree example and I think I got it right.
In removeInvalidPointsFromNodes(), line 294 - last element we swap with can also be invalid and, as result, skipped.
Without this change, after call to incrementalUpdate() there are points duplicates.

I simply put remove_if. Hope that makes sense.
On my PC, release build, without vsync, this improves CPU perf 2x with default options.

