### PR TITLE
Update viewer.dox: fix example

### DIFF
--- a/doc/viewer.dox
+++ b/doc/viewer.dox
@@ -324,6 +324,7 @@ them.
 @until }
 @until }
 @until }
+@until }
 
 Finally, the draw event only delegates to the camera, which draws everything
 in our drawable group.


### PR DESCRIPTION
The example on https://doc.magnum.graphics/magnum/examples-viewer.html for `void ColoredDrawable::draw` appears truncated

![Screenshot 2025-01-14 165709](https://github.com/user-attachments/assets/cc9eba15-a9e7-48a1-94a1-e50b18e073ac)

